### PR TITLE
fixed player movement issue

### DIFF
--- a/OpenGLTest/EventName.h
+++ b/OpenGLTest/EventName.h
@@ -7,7 +7,8 @@
 enum EventName {
     EVENT_EXAMPLE, // Example event type for demonstration purposes
 	PLAYER_JUMP,   // Used to trigger a player movement event
-	PLAYER_MOVE	
+	PLAYER_LEFT,
+	PLAYER_RIGHT
 };
 
 #endif

--- a/OpenGLTest/PhysicsManager.h
+++ b/OpenGLTest/PhysicsManager.h
@@ -22,6 +22,7 @@ private:
 	std::vector<Planetoid> *planets;
 	std::vector<PhysicsObject*> objects;
 	Map *map;
-	float input_X;
-	float player_jump_input;
+	bool player_left_input;
+	bool player_right_input;
+	bool player_jump_input;
 };

--- a/OpenGLTest/main.cpp
+++ b/OpenGLTest/main.cpp
@@ -44,41 +44,36 @@ void KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods
 	case GLFW_KEY_A:
 		if (action == GLFW_PRESS)
 		{
-			//std::cout << "W key pressed" << std::endl;
-			TypeParam<float> param(-1.0f);
-			EventManager::notify(PLAYER_MOVE, &param, false);
-		}
-		if (action == GLFW_REPEAT) {
-			//std::cout << "W key REPEATED" << std::endl;
+			TypeParam<bool> param(true);
+			EventManager::notify(PLAYER_LEFT, &param, false);
 		}
 		if (action == GLFW_RELEASE)
 		{
-			//std::cout << "W key released" << std::endl;
-			TypeParam<float> param(0.0f);
-			EventManager::notify(PLAYER_MOVE, &param, false);
+			TypeParam<bool> param(false);
+			EventManager::notify(PLAYER_LEFT, &param, false);
 		}
 		break;
 	case GLFW_KEY_D:
 		if (action == GLFW_PRESS)
 		{
-			TypeParam<float> param(1.0f);
-			EventManager::notify(PLAYER_MOVE, &param, false);
+			TypeParam<bool> param(true);
+			EventManager::notify(PLAYER_RIGHT, &param, false);
 		}
 		if (action == GLFW_RELEASE)
 		{
-			TypeParam<float> param(0.0f);
-			EventManager::notify(PLAYER_MOVE, &param, false);
+			TypeParam<bool> param(false);
+			EventManager::notify(PLAYER_RIGHT, &param, false);
 		}
 		break;
 	case GLFW_KEY_SPACE:
 		if (action == GLFW_PRESS)
 		{
-			TypeParam<float> param(1.0f);
+			TypeParam<bool> param(true);
 			EventManager::notify(PLAYER_JUMP, &param, false);
 		}
 		if (action == GLFW_RELEASE)
 		{
-			TypeParam<float> param(0.0f);
+			TypeParam<bool> param(false);
 			EventManager::notify(PLAYER_JUMP, &param, false);
 		}
 		break;
@@ -213,7 +208,8 @@ int main()
 	inputHandler.setInputCallbacks(window, KeyCallback, mouse_button_callback);
 	inputHandler.addKeyDownBinding(GLFW_KEY_Q, TestFunction); //example of registering a function to input handler. this function will be called whenever Q is tapped 
 
-	EventManager::subscribe(PLAYER_MOVE, physics); //Subscribe player move to EventManager
+	EventManager::subscribe(PLAYER_LEFT, physics); //Subscribe player left to EventManager
+	EventManager::subscribe(PLAYER_RIGHT, physics); //Subscribe player right to EventManager
 	EventManager::subscribe(PLAYER_JUMP, physics); //Subscribe player jump to EventManager
 
 


### PR DESCRIPTION
- when A or D is released don't naively set movement to 0
- set character rotation when close to planet, not just when on